### PR TITLE
0.2.1 RC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: curl -LsSf https://astral.sh/uv/install.sh | sh
       - run:
           name: Install dependencies
-          command: uv sync --frozen --group telegram
+          command: uv sync --frozen --extra telegram
       - run:
           name: "Are we on test mode?"
           command: echo ${TEST_MODE} # prints: XXXXXXX

--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ uv add git+https://github.com/veritable-tech/pytorch-lightning-spells.git@main
 
 ## Release Notes
 
+### 0.2.1 (2025-10-08)
+
+A small patch focused on clarity, type-safety, and minor robustness fixes. No public API changes; runtime behavior is preserved.
+
+- Metrics
+  - Rename internal state target → targets for clarity (internal only).
+  - Add guidance/warnings for AUC and FBeta specialized behavior; refactor compute paths with safer typing.
+  - Minor cleanup in SpearmanCorrelation.
+- Callbacks
+  - TelegramCallback: use event loop run_until_complete, re-enable on_exception, skip sanity validation, read from trainer.logged_metrics, and handle TimedOut gracefully.
+  - Lookahead callbacks: assert/operate only on Lookahead optimizers to prevent misuse.
+  - RandomAugmentationChoiceCallback: fix typing for p (Sequence[float]) and use random.choices.
+- Loggers
+  - ScreenLogger: sanitize and pretty-print hyperparams/metrics to ensure JSON-serializable output.
+- LR Schedulers
+  - Migrate base and multistage schedulers to torch.optim.lr_scheduler.LRScheduler; ensure initial LR setup via _initial_step.
+- CI
+  - Fix uv sync command and minor workflow hygiene.
+
+Compatibility notes
+
+- No breaking changes expected. Only the internal metric state name changed; user code depending on internal buffers should update from target to targets.
+
 ### 0.2.0 (2025-09-03)
 
 - This release modernizes the project's tooling, dependency management, and testing infrastructure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "pytorch-lightning>=2.5.0,<2.6.0",
     "scikit-learn>=1.7.1",
     "scipy>=1.16.1",
+    "typing-extensions>=4.15.0",
 ]
 author = "Ceshine Lee"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,15 @@ dependencies = [
 ]
 author = "Ceshine Lee"
 
+[project.optional-dependencies]
+telegram = [
+    "python-telegram-bot>=22.3",
+]
+
 [dependency-groups]
 dev = [
     "pytest>=8.4.1",
     "pytest-env>=1.1.5",
-]
-telegram = [
-    "python-telegram-bot>=22.3",
 ]
 
 [build-system]

--- a/pytorch_lightning_spells/callbacks.py
+++ b/pytorch_lightning_spells/callbacks.py
@@ -232,7 +232,8 @@ class TelegramCallback(Callback):
         except ImportError:
             raise ImportError("Please install 'python-telegram-bot' before using TelegramCallback.")
         try:
-            asyncio.run(self.telegram_bot.send_message(chat_id=self.chat_id, text=text))
+            event_loop = asyncio.get_event_loop()
+            event_loop.run_until_complete(self.telegram_bot.send_message(chat_id=self.chat_id, text=text))
         except telegram.error.TimedOut:
             # Ignore timeouts and continue training
             pass
@@ -277,9 +278,8 @@ class TelegramCallback(Callback):
         text = "\n".join(contents)
         self.send_message(text=text)
 
-    # Note: on_exception does not work as the main event loop will be closed during graceful shutdown
-    # def on_exception(self, trainer: pl.Trainer, pl_module: pl.LightningModule, exception: BaseException) -> None:
-    #     self.send_message(text=f"Exception occurred during training: {exception}")
+    def on_exception(self, trainer: pl.Trainer, pl_module: pl.LightningModule, exception: BaseException) -> None:
+        self.send_message(text=f"Exception occurred during training: {exception}")
 
     def _collect_metrics(self, trainer):
         ckpt_name_metrics = trainer.logged_metrics

--- a/pytorch_lightning_spells/loggers.py
+++ b/pytorch_lightning_spells/loggers.py
@@ -1,5 +1,76 @@
-from typing import Dict, Optional
+import json
+import numbers
+from enum import Enum
+from pprint import pprint
+from datetime import datetime, date
+from collections.abc import MutableMapping as _ABCMutableMapping
+from typing import Optional, MutableMapping, Any
+from typing_extensions import override
+
 from pytorch_lightning.loggers import Logger
+
+
+def _sanitize_value(x):
+    if x is None or isinstance(x, (bool, int, float, str)):
+        # No-op
+        return x
+    if isinstance(x, Enum):
+        # Prefer the raw value; fallback to name
+        return _sanitize_value(getattr(x, "value", x.name))
+    if isinstance(x, (datetime, date)):
+        return x.isoformat()
+    if isinstance(x, (bytes, bytearray, memoryview)):
+        try:
+            return bytes(x).decode("utf-8", errors="replace")
+        except Exception:
+            return str(x)
+    # Handle numpy/torch scalars
+    if hasattr(x, "item") and callable(getattr(x, "item")):
+        try:
+            scalar = x.item()
+            if isinstance(scalar, (bool, int, float, str)):
+                return scalar
+        except Exception:
+            pass
+    # Handle numpy arrays / torch tensors via tolist
+    if hasattr(x, "tolist") and callable(getattr(x, "tolist")):
+        try:
+            return x.tolist()
+        except Exception:
+            pass
+    # Generic numeric conversions (e.g., numpy numeric types)
+    if isinstance(x, numbers.Integral):
+        try:
+            return int(x)
+        except Exception:
+            pass
+    if isinstance(x, numbers.Real):
+        try:
+            return float(x)
+        except Exception:
+            pass
+    # Sequences
+    if isinstance(x, (list, tuple, set)):
+        return [_sanitize_value(v) for v in list(x)]
+    # Mappings
+    if isinstance(x, _ABCMutableMapping):
+        return {str(k): _sanitize_value(v) for k, v in x.items()}
+    if hasattr(x, "items") and callable(getattr(x, "items")):
+        try:
+            return {str(k): _sanitize_value(v) for k, v in x.items()}  # type: ignore
+        except Exception:
+            pass
+    # Last resort: keep if JSON can handle it, else stringify
+    try:
+        json.dumps(x)
+        return x
+    except Exception:
+        return str(x)
+
+
+def sanitize_dict_like_object(obj: MutableMapping[str, Any]) -> dict[str, Any]:
+    """Convert a dict-like object into a dict and ensure all values are JSON-serializable."""
+    return {str(k): _sanitize_value(v) for k, v in obj.items()}
 
 
 class ScreenLogger(Logger):
@@ -11,24 +82,34 @@ class ScreenLogger(Logger):
     def __init__(self):
         super().__init__()
 
-    def log_metrics(self, metrics: Dict[str, float], step: Optional[int] = None) -> None:
+    @override
+    def log_metrics(self, metrics: dict[str, float], step: Optional[int] = None) -> None:
         if any((key.startswith("val_") for key in metrics.keys())):
-            print("")
+            print("\n\n")
         for key, val in metrics.items():
             if key.startswith("val_"):
                 print(key, "%.4f" % val)
 
+    @override
     def log_hyperparams(self, params):
-        pass
+        if isinstance(params, _ABCMutableMapping):
+            pprint(sanitize_dict_like_object(params))
+        else:
+            pprint(params)
 
     @property
-    def experiment(self):
+    @override
+    def name(self):
         return None
 
     @property
-    def name(self):
-        return "screen_logger"
-
-    @property
+    @override
     def version(self) -> int:
         return 0
+
+    @property
+    @override
+    def save_dir(self) -> Optional[str]:
+        """Return the root directory where experiment logs get saved, or `None` if the logger does not save data
+        locally."""
+        return None

--- a/pytorch_lightning_spells/loggers.py
+++ b/pytorch_lightning_spells/loggers.py
@@ -100,7 +100,7 @@ class ScreenLogger(Logger):
     @property
     @override
     def name(self):
-        return None
+        return ""
 
     @property
     @override

--- a/pytorch_lightning_spells/utils.py
+++ b/pytorch_lightning_spells/utils.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 from torch.nn.parameter import Parameter
 import numpy as np
 
-Layer = Union[torch.nn.Module, torch.nn.ModuleList]
+Layer = Union[torch.nn.Module, torch.nn.ModuleList, list[torch.nn.Module]]
 
 
 class EMATracker:

--- a/pytorch_lightning_spells/version.py
+++ b/pytorch_lightning_spells/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1-dev.0"
+__version__ = "0.2.1-dev.1"
 __docs__ = "Some useful plugins for PyTorch Lightning."
 __author__ = "Ceshine Lee"
 __author_email__ = "ceshine@veritable.pw"

--- a/pytorch_lightning_spells/version.py
+++ b/pytorch_lightning_spells/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1-dev.2"
+__version__ = "0.2.1"
 __docs__ = "Some useful plugins for PyTorch Lightning."
 __author__ = "Ceshine Lee"
 __author_email__ = "ceshine@veritable.pw"

--- a/pytorch_lightning_spells/version.py
+++ b/pytorch_lightning_spells/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.2.1-dev.0"
 __docs__ = "Some useful plugins for PyTorch Lightning."
 __author__ = "Ceshine Lee"
 __author_email__ = "ceshine@veritable.pw"

--- a/pytorch_lightning_spells/version.py
+++ b/pytorch_lightning_spells/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1-dev.1"
+__version__ = "0.2.1-dev.2"
 __docs__ = "Some useful plugins for PyTorch Lightning."
 __author__ = "Ceshine Lee"
 __author_email__ = "ceshine@veritable.pw"

--- a/uv.lock
+++ b/uv.lock
@@ -847,6 +847,12 @@ dependencies = [
     { name = "pytorch-lightning" },
     { name = "scikit-learn" },
     { name = "scipy" },
+    { name = "typing-extensions" },
+]
+
+[package.optional-dependencies]
+telegram = [
+    { name = "python-telegram-bot" },
 ]
 
 [package.dev-dependencies]
@@ -854,23 +860,22 @@ dev = [
     { name = "pytest" },
     { name = "pytest-env" },
 ]
-telegram = [
-    { name = "python-telegram-bot" },
-]
 
 [package.metadata]
 requires-dist = [
+    { name = "python-telegram-bot", marker = "extra == 'telegram'", specifier = ">=22.3" },
     { name = "pytorch-lightning", specifier = ">=2.5.0,<2.6.0" },
     { name = "scikit-learn", specifier = ">=1.7.1" },
     { name = "scipy", specifier = ">=1.16.1" },
+    { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
+provides-extras = ["telegram"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
 ]
-telegram = [{ name = "python-telegram-bot", specifier = ">=22.3" }]
 
 [[package]]
 name = "pyyaml"


### PR DESCRIPTION
### Overview of the Changes

This pull request introduces a major modernization of the project's tooling, dependency management, and testing infrastructure. The build system has been migrated from `setup.py` to the standard `pyproject.toml`, and the CI/CD pipeline has been overhauled to use `uv` for significantly faster dependency management. A comprehensive test suite for the callback modules has been added, greatly improving code reliability.

Furthermore, the request includes numerous enhancements and bug fixes across the library, such as updating the `TelegramCallback` to work with modern libraries, improving the clarity and type safety of custom metrics, and migrating to the latest PyTorch `LRScheduler` API.

### Key Changes

*   **Project Modernization & Tooling**
    *   **Build System:** Migrated from `setup.py` to `pyproject.toml`, adopting the modern standard for Python packaging.
    *   **CI/CD Pipeline:** The CircleCI configuration has been completely revamped. It now uses `uv` for dependency installation, which is significantly faster than the previous `conda`/`pip` setup. A `ruff` linting step has also been added to enforce code quality.
    *   **Code Formatting & Linting:** Introduced `ruff` for code formatting and linting, with configuration added in a new `.pre-commit-config.yaml` file to automate style guide adherence.

*   **Comprehensive Testing**
    *   A new test file, `test_callbacks.py`, has been created, adding extensive unit and integration tests for all callbacks.
    *   Tests for `TelegramCallback` now use `unittest.mock.AsyncMock` to avoid making real network calls.
    *   Integration tests for `LookaheadCallback` and `LookaheadModelCheckpoint` verify correct parameter swapping and checkpointing behavior.
    *   Augmentation callback tests (`MixUp`, `CutMix`, `SnapMix`) have been added to ensure their transformations are applied correctly.

*   **Callback Improvements**
    *   **`TelegramCallback`**:
        *   Updated to use `event_loop.run_until_complete` for compatibility with the latest `python-telegram-bot` library.
        *   Now intelligently skips sending metrics during the initial sanity validation run.
        *   Reads metrics from `trainer.logged_metrics` for better compatibility with newer PyTorch Lightning versions.
        *   The `on_exception` hook has been re-enabled to report training failures.
    *   **`LookaheadCallback` & `LookaheadModelCheckpoint`**:
        *   Now explicitly assert that the attached optimizer is an instance of `Lookahead`, preventing incorrect usage and silent failures.
    *   **`RandomAugmentationChoiceCallback`**:
        *   Fixed a typing error and replaced `np.random.choice` with `random.choices` for better performance and consistency.

*   **Metrics Module Refinements**
    *   The base `GlobalMetric` class has been updated to align with recent changes in `torchmetrics`, removing the deprecated `compute_on_step` parameter.
    *   The internal state has been renamed from `target` to `targets` for improved clarity.
    *   `AUC` and `FBeta` metrics now issue warnings on initialization to clarify their specialized behavior (coalescing classes) and recommend standard `torchmetrics` alternatives for general use cases.
    *   Code within `compute` methods has been refactored for better readability and type safety using explicit casts.

*   **Other Notable Enhancements**
    *   **`ScreenLogger`**: Enhanced to sanitize hyperparameters, ensuring all values are JSON-serializable before being pretty-printed to the console.
    *   **Learning Rate Schedulers**: Migrated from the deprecated `_LRScheduler` to the public `torch.optim.lr_scheduler.LRScheduler` API.
    *   **Documentation**: The `README.md` file has been updated with a disclaimer, `uv` installation instructions, and a new "Release Notes" section.

### New Dependencies Added

*   **Build System:**
    *   `hatchling`: Added as the build backend in `pyproject.toml`.
*   **Development:**
    *   `pytest`, `pytest-env`: Formalized as development dependencies for running the new test suite.
*   **Optional:**
    *   `python-telegram-bot`: Defined as an optional dependency under the `[telegram]` extra, so it is only installed when needed.

Disclosure: the above pull request was written with the assistance of Gemini 2.5 Pro